### PR TITLE
Add CARTO basemap API key field for portal tile bake

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ On-device settings: page 2 = brightness, units, compass, sweep, timeouts, idle c
 2. Enter Wi‑Fi credentials (or manage **Saved networks**). You can also join the SSID manually and open `http://4.3.2.1` or the unique `http://flightscnr-xxxx.local`. Reboot the unit.
 3. After connect: safety disclaimer (touch **Accept**; optional **Don’t show again**) → About splash (~5 s) → radar. When acceptance is remembered, the disclaimer still appears for five seconds, then continues.
 4. Set radar center, weather key, and optional route APIs at `http://flightscnr-xxxx.local/` (or the device IP shown on settings page 1).
-5. Optional: **Radar basemap** card → pick style (**Dark Matter**, **Positron**, **Voyager**, or **VFR Sectional**) + contrast/wash + **Bake coverage**, then **Generate basemap**. Zooming out past the bake needs regenerate; center/facing/style changes do too.
+5. Optional: **Radar basemap** card → paste a free **CARTO API key** ([request here](https://carto.com/basemaps/apikey/)), pick style (**Dark Matter**, **Positron**, **Voyager**, or **VFR Sectional**) + contrast/wash + **Bake coverage**, then **Generate basemap**. Zooming out past the bake needs regenerate; center/facing/style changes do too.
 
 You can save up to **3** Wi‑Fi networks. Preference order is slot order (#1 tried first). Manage them from the setup portal (**Saved networks**) or the online settings page (**Wi‑Fi networks** card: add, remove, reorder, update password).
 

--- a/include/services/api_keys.h
+++ b/include/services/api_keys.h
@@ -26,11 +26,16 @@ bool hasAirLabs();
 bool hasFlightAware();
 bool hasFr24();
 bool hasWeather();
+bool hasCarto();
 
 /** Tomorrow.io weather key (single key). Returns "" when unset. */
 const char* weatherKey();
+/** CARTO basemap key for portal tile bake (single key). Returns "" when unset. */
+const char* cartoKey();
 /** Persist a new weather key from the web form; ignores null/empty. */
 bool saveWeatherKeyFromForm(const char* weather);
+/** Persist a new CARTO key from the web form; ignores null/empty. */
+bool saveCartoKeyFromForm(const char* carto);
 /** Portal/web checkbox ("T" = enabled). */
 void saveWeatherEnabledFromForm(const char* use_weather);
 
@@ -48,6 +53,7 @@ void saveOpenMeteoEnabledFromForm(const char* use_openmeteo);
 /** Free key-less Open-Meteo weather source enabled (default on). */
 bool useOpenMeteo();
 void maskedWeather(char* out, size_t len);
+void maskedCarto(char* out, size_t len);
 
 bool useAirLabs();
 bool useFlightAware();

--- a/src/services/api_keys.cpp
+++ b/src/services/api_keys.cpp
@@ -20,6 +20,7 @@ constexpr char kAirLabs[] = "al_key";
 constexpr char kFlightAware[] = "fa_key";
 constexpr char kFr24[] = "fr24_key";
 constexpr char kWeather[] = "wx_key";
+constexpr char kCarto[] = "carto_key";
 constexpr char kUseWeather[] = "wx_use";
 constexpr char kUseAirLabs[] = "al_use";
 constexpr char kUseFlightAware[] = "fa_use";
@@ -60,6 +61,7 @@ bool s_use_flightaware = false;
 bool s_use_fr24 = false;
 
 char s_weather_key[kMaxSingleKeyLen + 1] = {0};
+char s_carto_key[kMaxSingleKeyLen + 1] = {0};
 bool s_use_weather = true;
 bool s_use_adsbdb = true;
 bool s_use_openmeteo = true;
@@ -456,6 +458,11 @@ void load() {
   } else {
     s_weather_key[0] = '\0';
   }
+  if (prefs.isKey(kCarto)) {
+    copyBlob(s_carto_key, prefs.getString(kCarto).c_str(), sizeof(s_carto_key));
+  } else {
+    s_carto_key[0] = '\0';
+  }
   s_use_weather = prefs.getBool(kUseWeather, true);
   s_use_adsbdb = prefs.getBool(kUseAdsbDb, true);
   s_use_openmeteo = prefs.getBool(kUseOpenMeteo, true);
@@ -754,6 +761,18 @@ bool saveWeatherKeyFromForm(const char* weather) {
   return true;
 }
 
+bool hasCarto() { return s_carto_key[0] != '\0'; }
+
+const char* cartoKey() { return s_carto_key; }
+
+bool saveCartoKeyFromForm(const char* carto) {
+  if (!saveIfNonEmpty(carto, kCarto)) {
+    return false;
+  }
+  copyBlob(s_carto_key, carto, sizeof(s_carto_key));
+  return true;
+}
+
 void saveWeatherEnabledFromForm(const char* use_weather) {
   Preferences prefs;
   if (!prefs.begin(kNs, false)) {
@@ -793,6 +812,7 @@ void saveOpenMeteoEnabledFromForm(const char* use_openmeteo) {
 bool useOpenMeteo() { return s_use_openmeteo; }
 
 void maskedWeather(char* out, size_t len) { maskedPreviewSingle(s_weather_key, out, len); }
+void maskedCarto(char* out, size_t len) { maskedPreviewSingle(s_carto_key, out, len); }
 
 void maskedAirLabs(char* out, size_t len) { maskedPreviewProvider(s_airlabs, out, len); }
 void maskedFlightAware(char* out, size_t len) { maskedPreviewProvider(s_flightaware, out, len); }

--- a/src/services/settings_web.cpp
+++ b/src/services/settings_web.cpp
@@ -55,6 +55,8 @@ bool s_active = false;
 constexpr size_t kSettingsPageCap = 65536;
 char* s_settings_page = nullptr;
 
+int appendJsonString(char* out, size_t out_len, size_t* used, const char* value);
+
 char* settingsPageBuffer() {
   if (s_settings_page == nullptr) {
     s_settings_page = static_cast<char*>(
@@ -543,7 +545,9 @@ void handleSettingsPage() {
   // ---------- Radar basemap (Carto / FAA VFR bake) ----------
   {
     char bm_status[192];
+    char carto_masked[48];
     services::basemap::statusText(bm_status, sizeof(bm_status));
+    services::apikeys::maskedCarto(carto_masked, sizeof(carto_masked));
     const auto bm_style = services::basemap::hasImage()
                               ? services::basemap::storedStyle()
                               : services::basemap::Style::Dark;
@@ -562,7 +566,7 @@ void handleSettingsPage() {
         "<p class=\"note\">Optional map under the radar grid. "
         "Generated in your browser from <a href=\"https://carto.com/basemaps/\" "
         "target=\"_blank\" rel=\"noopener\">CARTO</a> (OSM, no city labels: Dark Matter, "
-        "Positron, Voyager) or "
+        "Positron, Voyager; free API key required) or "
         "FAA <a href=\"https://www.faa.gov/air_traffic/flight_info/aeronav/digital_products/vfr/\" "
         "target=\"_blank\" rel=\"noopener\">VFR Sectional</a> charts "
         "(dark/light/Voyager: contrast; VFR: pale wash toward white — set %% below), "
@@ -573,6 +577,12 @@ void handleSettingsPage() {
         "&copy; OpenStreetMap / &copy; CARTO / &copy; FAA."
         "</p>"
         "<p class=\"hint\" id=\"bm_status\">%s</p>"
+        "<label for=\"carto_key\">CARTO API key (%s)</label>"
+        "<input id=\"carto_key\" name=\"carto_key\" type=\"password\" autocomplete=\"off\" "
+        "placeholder=\"paste key\">"
+        "<p class=\"hint\">Required for Dark Matter, Positron, and Voyager bakes. "
+        "Free at <a href=\"https://carto.com/basemaps/apikey/\" target=\"_blank\" "
+        "rel=\"noopener\">carto.com/basemaps/apikey</a> (not needed for FAA VFR).</p>"
         "<label for=\"basemap_style\">Map style</label>"
         "<select id=\"basemap_style\">"
         "<option value=\"dark\"%s>Dark Matter (dark)</option>"
@@ -599,7 +609,7 @@ void handleSettingsPage() {
         "<option value=\"current\" selected>Current range (%u mi) — sharper</option>"
         "<option value=\"max\">Maximum range (%u mi) — zoom-friendly</option>"
         "</select>",
-        bm_status, dark_sel ? " selected" : "", light_sel ? " selected" : "",
+        bm_status, carto_masked, dark_sel ? " selected" : "", light_sel ? " selected" : "",
         voyager_sel ? " selected" : "", vfr_sel ? " selected" : "",
         static_cast<unsigned>(services::basemap::contrastPercentDark()),
         static_cast<unsigned>(services::basemap::contrastPercentLight()),
@@ -610,6 +620,13 @@ void handleSettingsPage() {
   appendToggle(page, kSettingsPageCap, &used, "use_basemap", "Show basemap on radar",
                services::basemap::enabled());
   {
+    char carto_js[services::apikeys::kMaxSingleKeyLen + 8];
+    size_t carto_js_len = 0;
+    appendJsonString(carto_js, sizeof(carto_js), &carto_js_len, services::apikeys::cartoKey());
+    if (carto_js_len >= sizeof(carto_js)) {
+      carto_js_len = sizeof(carto_js) - 1;
+    }
+    carto_js[carto_js_len] = '\0';
     const int bm2 = snprintf(
         page + used, kSettingsPageCap - used,
         "<p style=\"margin-top:.6rem\">"
@@ -620,6 +637,7 @@ void handleSettingsPage() {
         "(function(){"
         "var SIZE=%d,CX=%d,CY=%d,OUTER=%d;"
         "var lat=%.6f,lon=%.6f,curMiles=%u,maxMiles=%u,facing=%u;"
+        "var cartoKey=%s;"
         "var msg=document.getElementById('bm_msg');"
         "var styleEl=document.getElementById('basemap_style');"
         "var covEl=document.getElementById('basemap_coverage');"
@@ -668,10 +686,12 @@ void handleSettingsPage() {
         "if(styleKey()==='vfr')"
         "return'https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/"
         "VFR_Sectional/MapServer/tile/'+z+'/'+y+'/'+x;"
-        "var path='dark_nolabels';"
-        "if(styleKey()==='light')path='light_nolabels';"
+        "var path='rastertiles/dark_nolabels';"
+        "if(styleKey()==='light')path='rastertiles/light_nolabels';"
         "else if(styleKey()==='voyager')path='rastertiles/voyager_nolabels';"
-        "return'https://a.basemaps.cartocdn.com/'+path+'/'+z+'/'+x+'/'+y+'.png';}"
+        "var url='https://a.basemaps.cartocdn.com/'+path+'/'+z+'/'+x+'/'+y+'.png';"
+        "if(cartoKey)url+='?key='+encodeURIComponent(cartoKey);"
+        "return url;}"
         "function loadTile(z,x,y){return new Promise(function(res,rej){"
         "var i=new Image();i.crossOrigin='anonymous';"
         "i.onload=function(){res(i)};"
@@ -680,6 +700,9 @@ void handleSettingsPage() {
         "else rej(new Error('tile '+z+'/'+x+'/'+y));};"
         "i.src=tileUrl(z,x,y);});}"
         "async function bake(){"
+        "if(styleKey()!=='vfr'&&!cartoKey){"
+        "msg.textContent='CARTO API key required — paste key above, Save, then Generate';"
+        "return;}"
         "await persistBakeAdjust();"
         "var miles=bakeMiles(),labelKm=miles*1.609344,ppm=OUTER/labelKm;"
         "var coverR=Math.ceil(Math.hypot(CX,CY))+2;"
@@ -757,7 +780,7 @@ void handleSettingsPage() {
         static_cast<unsigned>(ui::radar::scaleActiveMiles()),
         static_cast<unsigned>(
             ui::radar::kRangeMileOptions[ui::radar::kRangeMileOptionCount - 1]),
-        static_cast<unsigned>(ui::radar::facingDeg()),
+        static_cast<unsigned>(ui::radar::facingDeg()), carto_js,
         static_cast<unsigned>(services::basemap::contrastPercentDark()),
         static_cast<unsigned>(services::basemap::contrastPercentLight()),
         static_cast<unsigned>(services::basemap::washPercentVfr()));
@@ -1331,7 +1354,7 @@ void handleSettingsPage() {
       "<script>"
       "(function(){"
       "var lastRev=null,timer=null,PASSWORD_IDS={"
-      "airlabs_key:1,flightaware_key:1,fr24_key:1,weather_key:1"
+      "airlabs_key:1,flightaware_key:1,fr24_key:1,weather_key:1,carto_key:1"
       "};"
       "function setVal(id,v){"
       "var el=document.getElementById(id);if(!el||PASSWORD_IDS[id])return;"
@@ -1463,6 +1486,7 @@ void handleSave() {
   const bool use_openmeteo_before = services::apikeys::useOpenMeteo();
   const bool weather_key_saved =
       services::apikeys::saveWeatherKeyFromForm(s_server->arg("weather_key").c_str());
+  services::apikeys::saveCartoKeyFromForm(s_server->arg("carto_key").c_str());
   services::apikeys::saveWeatherEnabledFromForm(s_server->arg("use_weather").c_str());
   services::apikeys::saveOpenMeteoEnabledFromForm(s_server->arg("use_openmeteo").c_str());
   services::apikeys::saveAdsbDbEnabledFromForm(s_server->arg("use_adsbdb").c_str());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CARTO raster basemaps now require a free API key. This adds portal support matching the existing weather/route key pattern.

## Changes

- **NVS storage** (`api_keys.cpp`): new `carto_key` preference with `cartoKey()`, `hasCarto()`, `saveCartoKeyFromForm()`, and `maskedCarto()`.
- **Web portal** (`settings_web.cpp`): password field under **Radar basemap** with link to [carto.com/basemaps/apikey](https://carto.com/basemaps/apikey).
- **Basemap bake JS**: appends `?key=` to CARTO tile URLs, uses `rastertiles/…` paths, and blocks Dark/Positron/Voyager generation until a key is saved (FAA VFR unchanged).
- **README**: notes the CARTO key step in first-time setup.

## How to use

1. Open the device settings portal → **Radar basemap**.
2. Paste your free CARTO API key → **Save**.
3. Click **Generate basemap** for a CARTO style.

Without a key, CARTO tiles show the “API key required” watermark and bake fails early with a clear message.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04915-54e1-79ed-8184-87e9654a8ff5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04915-54e1-79ed-8184-87e9654a8ff5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

